### PR TITLE
Expanded pyez_route_info.py

### DIFF
--- a/nornir_pyez/plugins/tasks/pyez_route_info.py
+++ b/nornir_pyez/plugins/tasks/pyez_route_info.py
@@ -9,10 +9,53 @@ import json
 
 def pyez_route_info(
     task: Task,
+    all: bool = False,
+    best: bool = False,
+    brief: bool = False,
+    detail: bool = False,
+    exact: bool = False,
+    hidden: bool = False,
+    localization: bool = False, # get-fib-localization-information
+    martians: bool = False,     # get-route-martians
+    private: bool = False,
+    instance_name: str = "all", # get-instance-information
+    protocol: str = "all",
+    table: str = "all",
+    rib_sharding: str = "main",
+    destination: str = "",
 ) -> Result:
 
+    cmd_args = {}
+    if destination is not "":
+        cmd_args["destination"]=destination
+        ## TODO: Process route flags (exact, etc)
+    if protocol is not "all":
+        cmd_args["protocol"]=protocol
+    if instance_name is not "all":
+        cmd_args["instance_name"]=instance_name
+    if table is not "all":
+        cmd_args["table"]=table
+    if rib_sharding is not "main":
+        cmd_args["rib-sharding"]=rib_sharding
+    if hidden:
+        cmd_args["hidden"]=hidden
+    if all:
+        cmd_args["all"]=all
+    if private:
+        cmd_args["private"]=private
+
+    # Connect to Device
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-    data = device.rpc.get_route_information()
+
+    if martians:
+        data = device.rpc.get_route_martians(**cmd_args)
+    elif localization:
+        data = device.rpc.get_fib_localization_information(**cmd_args)
+    elif instance_name is not "all":
+        ## TODO: Doesn't work - NameError: name 'instance' is not defined
+        data = device.rpc.get-instance-information(**cmd_args)
+    else:
+        data = device.rpc.get_route_information(**cmd_args)
     data = etree.tostring(data, encoding='unicode', pretty_print=True)
     parsed = xmltodict.parse(data)
     clean_parse = json.loads(json.dumps(parsed))


### PR DESCRIPTION
Added a few options to the command to pull routing information. The instance-name option needs some attention, and other options still need to be implemented. But this will allow the output be limited by supernet and protocol. (show route protocol static 10.0.0.0/16)

Since some of the options require a different command, the structure to handle that was added, but there is no checking for mutually exclusive options. 